### PR TITLE
Fix various Python 3.12 SyntaxWarning

### DIFF
--- a/lib/termineter/interface.py
+++ b/lib/termineter/interface.py
@@ -124,10 +124,10 @@ class InteractiveInterpreter(termineter.cmd.Cmd):
 	@property
 	def intro(self):
 		intro = os.linesep
-		intro += '   ______              _          __         ' + os.linesep
-		intro += '  /_  __/__ ______ _  (_)__  ___ / /____ ____' + os.linesep
-		intro += '   / / / -_) __/  \' \/ / _ \/ -_) __/ -_) __/' + os.linesep
-		intro += '  /_/  \__/_/ /_/_/_/_/_//_/\__/\__/\__/_/   ' + os.linesep
+		intro += r'   ______              _          __         ' + os.linesep
+		intro += r'  /_  __/__ ______ _  (_)__  ___ / /____ ____' + os.linesep
+		intro += r'   / / / -_) __/  \' \/ / _ \/ -_) __/ -_) __/' + os.linesep
+		intro += r'  /_/  \__/_/ /_/_/_/_/_//_/\__/\__/\__/_/   ' + os.linesep
 		intro += os.linesep
 		fmt_string = "  <[ {0:<18} {1:>18}"
 		intro += fmt_string.format(self.__name__, 'v' + termineter.__version__) + os.linesep


### PR DESCRIPTION
Fixes the following:

```
/usr/lib/python3/dist-packages/termineter/interface.py:129: SyntaxWarning: invalid escape sequence '\/'
  intro += '   / / / -_) __/  \' \/ / _ \/ -_) __/ -_) __/' + os.linesep
/usr/lib/python3/dist-packages/termineter/interface.py:130: SyntaxWarning: invalid escape sequence '\_'
  intro += '  /_/  \__/_/ /_/_/_/_/_//_/\__/\__/\__/_/   ' + os.linesep
```